### PR TITLE
Add default widget_props parse

### DIFF
--- a/src/Timeline.ts
+++ b/src/Timeline.ts
@@ -27,16 +27,9 @@ class Timeline extends One2many {
     super(props);
     this._titleField = "";
     this._summaryField = "";
-
-    if (props?.widget_props) {
-
-      try {
-        const parsedWidgetProps = JSON.parse(props.widget_props.replace(/'/g, '"'));
-        this._titleField = parsedWidgetProps.titleField;
-        this._summaryField = parsedWidgetProps.summaryField;
-      } catch(err) {
-        throw new Error(`Timeline - error parsing widget_props: ${JSON.stringify(err)}`);
-      }
+    if (this._parsedWidgetProps) {
+      this._titleField = this._parsedWidgetProps.titleField;
+      this._summaryField = this.parsedWidgetProps.summaryField;
     }
   }
 }

--- a/src/Widget.ts
+++ b/src/Widget.ts
@@ -76,6 +76,14 @@ abstract class Widget {
     this._domain = value;
   }
 
+  _parsedWidgetProps: any;
+  get parsedWidgetProps(): any {
+    return this._parsedWidgetProps;
+  }
+  set parsedWidgetProps(value: any) {
+    this._parsedWidgetProps = value;
+  }
+
   constructor(props?: any) {
     this._colspan = Widget._defaultColspan;
     this._readOnly = false;
@@ -112,6 +120,14 @@ abstract class Widget {
       if (props.domain && typeof props.domain === "string") {
         this._domain = props.domain;
       }
+      if (props.widget_props) {
+
+      try {
+        this._parsedWidgetProps = JSON.parse(props.widget_props.replace(/'/g, '"'));
+      } catch(err) {
+        throw new Error('Error parsing widget_props');
+      }
+    }
     }
   }
 

--- a/src/spec/Timeline.spec.ts
+++ b/src/spec/Timeline.spec.ts
@@ -1,0 +1,38 @@
+import WidgetFactory from "../WidgetFactory";
+import Timeline from "../Timeline";
+
+describe("A Timeline", () => {
+  it("should have an id corresponding to field name", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "timeline_field",
+    };
+
+    const widget = widgetFactory.createWidget("timeline", props);
+    expect(widget).toBeInstanceOf(Timeline);
+    expect(widget.id).toBe("timeline_field");
+
+  });
+
+  it("should properly set readonly", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "timeline_field",
+      readonly: 1,
+    };
+    const widget = widgetFactory.createWidget("timeline", props);
+
+    expect(widget.readOnly).toBe(true);
+  });
+
+  it('should parse widget props', () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "timeline_field",
+      widget_props: "{'titleField': 'tfield', 'summaryField': 'sfield'}"
+    };
+    const widget = widgetFactory.createWidget("timeline", props);
+    expect(widget.summaryField).toBe('sfield');
+    expect(widget.titleField).toBe('tfield');
+  });
+});

--- a/src/spec/Widget.spec.ts
+++ b/src/spec/Widget.spec.ts
@@ -31,6 +31,29 @@ describe('A Widget', () => {
 
         expect(typeof widget.colspan).toBe("number");
     });
+    describe('Parsing widget props', () => {
+        it('should parse widget_props', () => {
+            const props = {
+                widget_props: "{'prop_1': 1, 'prop_2': 'prop2'}"
+            }
+            const widget = new WidgetImpl(props);
+            expect(JSON.stringify(widget.parsedWidgetProps)).toBe(
+              JSON.stringify({prop_1: 1, prop_2: 'prop2'})
+            )
+        });
+        it('should fail if widget props are not valid', () => {
+            const props = {
+                widget_props: "{'prop_1: 1, 'prop_2': 'prop2'}"
+            }
+            expect.assertions(1);
+            try {
+                new WidgetImpl(props);
+            } catch (e) {
+                expect(e.message).toBe('Error parsing widget_props');
+            }
+
+        });
+    });
 
     /*
     it('set colspan as string should store as a number', () => {


### PR DESCRIPTION
- Add a `widget_props` parse to default widget
- Add tests for `Timeline`
- `Timeline` use default widget props parse

This is required for new props for `Indicator` widget