### PR TITLE
Allow label props

### DIFF
--- a/src/Label.ts
+++ b/src/Label.ts
@@ -1,5 +1,9 @@
 import Field from "./Field";
 
+
+type LabelType = "secondary" | "success" | "warning" | "danger" | "default";
+type LabelSize = "h1" | "h2" | "h3" | "h4" | "h5" | "text";
+
 class Label extends Field {
   /**
    * Label text
@@ -24,6 +28,29 @@ class Label extends Field {
   }
 
   /**
+   * Label type
+   */
+  _labelType: LabelType = "default";
+  get labelType(): LabelType {
+    return this._labelType;
+  }
+  set labelType(value: LabelType) {
+    this._labelType = value;
+  }
+
+  /**
+   * Label size
+   */
+   _labelSize: LabelSize = "text";
+   get labelSize(): LabelSize {
+     return this._labelSize;
+   }
+   set labelSize(value: LabelSize) {
+     this._labelSize = value;
+   }
+
+
+  /**
    * Id of the field that this label goes with. Null if it's an independent label
    */
   _fieldForLabel: string | null = null;
@@ -39,6 +66,14 @@ class Label extends Field {
 
     if (props?.fieldForLabel) {
       this._fieldForLabel = props.fieldForLabel;
+    }
+    if (props.widget_props) {
+      if (this.parsedWidgetProps.label_type) {
+        this.labelType = this.parsedWidgetProps.label_type;
+      }
+      if (this.parsedWidgetProps.label_size) {
+        this.labelSize = this.parsedWidgetProps.label_size;
+      }
     }
   }
 }

--- a/src/spec/Label.spec.ts
+++ b/src/spec/Label.spec.ts
@@ -43,4 +43,51 @@ describe("A Label", () => {
     const widget = widgetFactory.createWidget("label", props);
     expect(widget.fieldForLabel).toBe("field");
   });
+
+  describe("Label types", () => {
+    it("should have default type by default", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "field_label",
+        string: "Default",
+      };
+      const widget = widgetFactory.createWidget("label", props);
+      expect(widget.labelType).toBe("default");
+    });
+    it("should parse label_type from widget props", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "field_label",
+        string: "Default",
+        widget_props: "{'label_type': 'warning'}"
+      };
+      const widget = widgetFactory.createWidget("label", props);
+      expect(widget.labelType).toBe("warning");
+    });
+  });
+
+  describe("Label size", () => {
+    it("should have default size to text", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "field_label",
+        string: "Default",
+        widget_props: "{}"
+      };
+      const widget = widgetFactory.createWidget("label", props);
+      expect(widget.labelSize).toBe("text");
+    });
+    it("should have allow size to h1...h5", () => {
+      const widgetFactory = new WidgetFactory();
+      ['h1', 'h2', 'h3', 'h4', 'h5'].map((level) => {
+        const props = {
+          name: "field_label",
+          string: "Default",
+          widget_props: `{'label_size': '${level}'}`
+        };
+        const widget = widgetFactory.createWidget("label", props);
+        expect(widget.labelSize).toBe(level);
+      })
+    });
+  });
 });


### PR DESCRIPTION
Allow new props: 
- Label type: 'default', 'secondary', 'warning', 'danger', 'success'
- Label size': 'text', 'h1', 'h2', 'h3', 'h4', 'h5'