### PR TITLE
Order pie charts by value

### DIFF
--- a/src/Graph/processor/graphProcessor.ts
+++ b/src/Graph/processor/graphProcessor.ts
@@ -167,6 +167,8 @@ export const processGraphData = ({
       values: finalData,
       timerange: ooui.timerange!,
     });
+  } else if (ooui.type == "pie") {
+    finalData = adjustedUninformedData.sort((a, b) => b.value - a.value);
   }
 
   return {


### PR DESCRIPTION
D'aquesta forma el pie ens queda més ordenat de la següent forma:

![image](https://user-images.githubusercontent.com/294235/232533713-61171e54-63bc-4946-926f-dddba600bc08.png)

i la llegenda correspon amb l'ordre de més a menys