### PR TITLE
Add status attribute on tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gisce/ooui",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gisce/ooui",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "html-entities": "^2.3.3",
         "moment": "^2.29.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gisce/ooui",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "main": "./dist/ooui.umd.js",
   "module": "./dist/ooui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/Tree.ts
+++ b/src/Tree.ts
@@ -41,6 +41,11 @@ class Tree {
     return this._colors;
   }
 
+  _status: string | null = null;
+  get status(): string | null {
+    return this._status;
+  }
+
   /**
    * Editable value
    */
@@ -62,6 +67,10 @@ class Tree {
     this._colors = view.attributes.colors || null;
     if (this._colors) {
       this._colors = replaceEntities(this._colors);
+    }
+    this._status = view.attributes.status || null;
+    if (this._status) {
+      this._status = replaceEntities(this._status);
     }
     this._editable = view.attributes.editable || null;
     const widgetFactory = new WidgetFactory();

--- a/src/spec/Tree.spec.ts
+++ b/src/spec/Tree.spec.ts
@@ -3,7 +3,7 @@ import Char from "../Char";
 import FloatTime from "../FloatTime";
 
 const XML_VIEW_TREE = `<?xml version="1.0"?>
-<tree string="Partners" colors="red:debt_amount&gt;0 &amp; city!=''">
+<tree string="Partners" colors="red:debt_amount&gt;0 &amp; city!=''" status="red:debt_amount&gt;0;green:debt_amount==0">
   <field name="name"/>
   <field name="title"/>
   <field name="ref"/>
@@ -87,6 +87,8 @@ describe("A Tree", () => {
     expect(nameWidget.label).toBe("Name");
     expect(tree.colors).toBeDefined();
     expect(tree.colors).toBe("red:debt_amount>0 & city!=''")
+    expect(tree.status).toBeDefined();
+    expect(tree.status).toBe("red:debt_amount>0;green:debt_amount==0")
   });
   it("Must throw an error if a field isn't present in field definitions", () => {
     const parseInvalidTree = () => {


### PR DESCRIPTION
Allow to define `status` for a tree.

```xml
<tree string="Invoices" status="red:validations>0;green:validations==0">
...
</tree>
```