### PR TITLE
Allow help to be inline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gisce/ooui",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gisce/ooui",
-      "version": "0.22.4",
+      "version": "0.22.5",
       "dependencies": {
         "html-entities": "^2.3.3",
         "moment": "^2.29.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gisce/ooui",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "main": "./dist/ooui.umd.js",
   "module": "./dist/ooui.es.js",
   "types": "./dist/index.d.ts",

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -1,5 +1,5 @@
 import Widget from "./Widget";
-import { replaceEntities } from "./helpers/attributeParser";
+import { replaceEntities, isTrue } from "./helpers/attributeParser";
 
 class Field extends Widget {
   /**
@@ -63,6 +63,18 @@ class Field extends Widget {
   set tooltip(value: string | undefined) {
     this._tooltip = value;
   }
+
+  /**
+   * Tooltip inline
+   */
+  _tooltipInline: boolean = false;
+  get tooltipInline(): boolean {
+    return this._tooltipInline;
+  }
+  set tooltipInline(value: boolean) {
+    this._tooltipInline = value;
+  }
+
 
   /**
    * Activated (default is true)
@@ -143,6 +155,10 @@ class Field extends Widget {
 
       if (props.selection) {
         this._selectionValues = new Map(props.selection);
+      }
+
+      if (props.help_inline) {
+        this.tooltipInline = isTrue(props.help_inline);
       }
     }
   }

--- a/src/helpers/attributeParser.ts
+++ b/src/helpers/attributeParser.ts
@@ -1,5 +1,10 @@
 import { decode } from "html-entities";
 
+export const isTrue = (value: string | boolean | number = false) => {
+  value = JSON.parse(value.toString().toLowerCase())
+  return (+ value > 0)
+}
+
 const evaluateCondition = ({
   entry,
   values,

--- a/src/spec/Form.spec.ts
+++ b/src/spec/Form.spec.ts
@@ -334,29 +334,54 @@ describe("A Form", () => {
     }
   });
 
-  it("should be able to parse a field with tooltip", () => {
-    const fields = {
-      char1: {
-        size: 128,
-        string: "Name",
-        type: "char",
-        help: "tooltip string",
-      },
-    };
-    const xmlViewForm = `<?xml version="1.0"?>
-    <form string="Form1">
-        <group name="group">
-            <field colspan="1" name="char1" />
-        </group>
-    </form>`;
-    const form = new Form(fields);
-    form.parse(xmlViewForm);
+  describe("If field has a help message", () => {
+    it("should be able to parse a field with tooltip", () => {
+      const fields = {
+        char1: {
+          size: 128,
+          string: "Name",
+          type: "char",
+          help: "tooltip string",
+        },
+      };
+      const xmlViewForm = `<?xml version="1.0"?>
+      <form string="Form1">
+          <group name="group">
+              <field colspan="1" name="char1" />
+          </group>
+      </form>`;
+      const form = new Form(fields);
+      form.parse(xmlViewForm);
 
-    const field = form.findById("char1") as Char;
-    expect(field).not.toBeNull();
-    expect(field.tooltip).toBe("tooltip string");
-  });
+      const field = form.findById("char1") as Char;
+      expect(field).not.toBeNull();
+      expect(field.tooltip).toBe("tooltip string");
+      expect(field.tooltipInline).toBeFalsy();
+    });
+    it("should be inline if attribute help_inline is set", () => {
+      const fields = {
+        char1: {
+          size: 128,
+          string: "Name",
+          type: "char",
+          help: "tooltip string",
+        },
+      };
+      const xmlViewForm = `<?xml version="1.0"?>
+      <form string="Form1">
+          <group name="group">
+              <field colspan="1" name="char1" help_inline="1"/>
+          </group>
+      </form>`;
+      const form = new Form(fields);
+      form.parse(xmlViewForm);
 
+      const field = form.findById("char1") as Char;
+      expect(field).not.toBeNull();
+      expect(field.tooltip).toBe("tooltip string");
+      expect(field.tooltipInline).toBeTruthy();
+    });
+  })
   it("should properly parse a password field", () => {
     const arch =
       '<form><group><field name="password" password="True" readonly="0"/></group></form>';

--- a/src/spec/attributeParser.spec.ts
+++ b/src/spec/attributeParser.spec.ts
@@ -1,4 +1,4 @@
-import { evaluateAttributes } from "../helpers/attributeParser";
+import { evaluateAttributes, isTrue } from "../helpers/attributeParser";
 
 const fields = {
   force_potencia_adscrita: {
@@ -210,5 +210,40 @@ describe("An Attribute Parser", () => {
       });
       expect(evaluatedAttrs.invisible).toBeTruthy();
     });
+  });
+  describe("isTrue method", () => {
+    it("should return true when value is 'True'", () => {
+      expect(isTrue('True')).toBeTruthy();
+    })
+    it("should return true when value is 'true'", () => {
+      expect(isTrue('true')).toBeTruthy();
+    })
+    it("should return true when value is true", () => {
+      expect(isTrue(true)).toBeTruthy();
+    })
+    it("should return true when value is '1'", () => {
+      expect(isTrue('1')).toBeTruthy();
+    })
+    it("should return true when value is 1", () => {
+      expect(isTrue(1)).toBeTruthy();
+    })
+    it("should return false when value is 'False'", () => {
+      expect(isTrue('False')).toBeFalsy();
+    })
+    it("should return false when value is 'false'", () => {
+      expect(isTrue('false')).toBeFalsy();
+    })
+    it("should return false when value is false", () => {
+      expect(isTrue(false)).toBeFalsy();
+    })
+    it("should return false when value is '0'", () => {
+      expect(isTrue('0')).toBeFalsy();
+    })
+    it("should return false when value is 0", () => {
+      expect(isTrue(0)).toBeFalsy();
+    })
+    it("should return false when value is undefined", () => {
+      expect(isTrue(undefined)).toBeFalsy();
+    })
   });
 });


### PR DESCRIPTION
A new property to allow help message to be in the form or a tooltip

```xml
<field name="a_field" help_inline="1" />
```

Part of https://github.com/gisce/webclient/issues/673