### PR TITLE
Add interval to getMissingConsecutiveDates

### DIFF
--- a/src/Graph/Graph.ts
+++ b/src/Graph/Graph.ts
@@ -18,8 +18,16 @@ export class Graph {
     return this._timerange;
   }
 
+  _interval: number = 1;
+  get interval(): number {
+    return this._interval;
+  }
+
   constructor(element: ParsedNode) {
     this._string = element.attributes.string || null;
     this._timerange = element.attributes.timerange || null;
+    if (element.attributes.interval) {
+      this._interval = parseInt(element.attributes.interval);
+    }
   }
 }

--- a/src/Graph/processor/graphProcessor.ts
+++ b/src/Graph/processor/graphProcessor.ts
@@ -167,6 +167,7 @@ export const processGraphData = ({
     finalData = processTimerangeData({
       values: finalData,
       timerange: ooui.timerange,
+      interval: ooui.interval,
     });
   } else if (ooui.type == "pie") {
     finalData = adjustedUninformedData.sort((a, b) => b.value - a.value);

--- a/src/Graph/processor/timerangeHelper.ts
+++ b/src/Graph/processor/timerangeHelper.ts
@@ -4,9 +4,11 @@ import { getValueForOperator } from "./graphProcessor";
 export function processTimerangeData({
   values,
   timerange,
+  interval = 1,
 }: {
   values: any[];
   timerange: string;
+  interval?: number;
 }) {
   const combinedValues = combineValuesForTimerange({
     values,
@@ -17,6 +19,7 @@ export function processTimerangeData({
   const filledValues = fillGapsInTimerangeData({
     values: combinedValues,
     timerange,
+    interval,
   });
 
   return filledValues;
@@ -25,9 +28,11 @@ export function processTimerangeData({
 export function fillGapsInTimerangeData({
   values,
   timerange,
+  interval = 1,
 }: {
   values: any[];
   timerange: string;
+  interval?: number;
 }) {
   let finalValues: any[] = [];
   const uniqueValues: Record<string, any> = getUniqueValuesGroupedBy({
@@ -56,6 +61,7 @@ export function fillGapsInTimerangeData({
         const missingDates = getMissingConsecutiveDates({
           dates: [date, nextDate],
           timerange,
+          interval,
         });
         finalValues = finalValues.concat(
           missingDates.map((stringDate) => {

--- a/src/Graph/processor/timerangeHelper.ts
+++ b/src/Graph/processor/timerangeHelper.ts
@@ -86,9 +86,11 @@ export function fillGapsInTimerangeData({
 export function getMissingConsecutiveDates({
   dates,
   timerange,
+  interval = 1,
 }: {
   dates: string[];
   timerange: string;
+  interval?: number;
 }) {
   const missingDates: string[] = [];
   const units = `${timerange}s` as any;
@@ -111,12 +113,15 @@ export function getMissingConsecutiveDates({
     const date2 = sortedDates[i + 1];
 
     if (!checkDatesConsecutive([date1, date2], units)) {
-      const iDate = moment(date1, getFormatForUnits(units)).add(1, units);
+      const iDate = moment(date1, getFormatForUnits(units)).add(
+        interval,
+        units,
+      );
       const fDate = moment(date2, getFormatForUnits(units));
 
       while (iDate.isBefore(fDate)) {
         missingDates.push(iDate.format(getFormatForUnits(units)));
-        iDate.add(1, units);
+        iDate.add(interval, units);
       }
     }
   }

--- a/src/spec/Graph.spec.ts
+++ b/src/spec/Graph.spec.ts
@@ -66,4 +66,15 @@ describe("A Graph", () => {
     const graph = parseGraph(xml) as GraphChart;
     expect(graph.timerange).toBe("day");
   });
+  it("should parse a graph with interval parameter", () => {
+    const xml = `<?xml version="1.0"?>
+    <graph type="line" timerange="minute" interval="5">
+        <field name="data_alta" axis="x"/>
+        <field name="data_alta" operator="count" axis="y"/>
+    </graph>
+    `;
+
+    const graph = parseGraph(xml) as GraphChart;
+    expect(graph.interval).toBe(5);
+  });
 });

--- a/src/spec/timerangeHelper.spec.ts
+++ b/src/spec/timerangeHelper.spec.ts
@@ -569,6 +569,27 @@ describe("a timerangeHelper", () => {
       expect(missingDates.length).toBe(1);
       expect(missingDates[0]).toBe("2022-01");
     });
+    it("should allow to pass an interval to get missing dates", () => {
+      const dates = ["2024-01-01 00:00", "2024-01-01 01:00"];
+      const missingDates = getMissingConsecutiveDates({
+        dates,
+        timerange: "minute",
+        interval: 5,
+      });
+      expect(missingDates).toEqual([
+        "2024-01-01 00:05",
+        "2024-01-01 00:10",
+        "2024-01-01 00:15",
+        "2024-01-01 00:20",
+        "2024-01-01 00:25",
+        "2024-01-01 00:30",
+        "2024-01-01 00:35",
+        "2024-01-01 00:40",
+        "2024-01-01 00:45",
+        "2024-01-01 00:50",
+        "2024-01-01 00:55",
+      ]);
+    });
   });
   describe("in fillGapsInTimerangeData function", () => {
     it("should fill gaps in data for hour grouping", () => {


### PR DESCRIPTION
This will allow us to get missing dates only from our defined interval, for example if we only want to fill gaps every five minutes we can use:

```typescript
const dates = ["2024-01-01 00:00", "2024-01-01 01:00"];
const missingDates = getMissingConsecutiveDates({
  dates,
  timerange: "minute",
  interval: 5,
});
```
And we will get:

```javascript
[
  "2024-01-01 00:05",
  "2024-01-01 00:10",
  "2024-01-01 00:15",
  "2024-01-01 00:20",
  "2024-01-01 00:25",
  "2024-01-01 00:30",
  "2024-01-01 00:35",
  "2024-01-01 00:40",
  "2024-01-01 00:45",
  "2024-01-01 00:50",
  "2024-01-01 00:55",
]
```

>[!WARNING]
> This only adds missing dates in the interval, it **doesn't aggregate by this interval**