### PR TITLE
showCount property

### DIFF
--- a/src/Char.ts
+++ b/src/Char.ts
@@ -16,6 +16,10 @@ class Char extends Field {
     this._placeholder = value;
   }
 
+  get showCount(): boolean {
+    return this.parsedWidgetProps.showCount || false;
+  }
+
   /**
    * Field size
    */

--- a/src/Text.ts
+++ b/src/Text.ts
@@ -17,6 +17,22 @@ class Text extends Field {
     this._placeholder = value;
   }
 
+  get showCount(): boolean {
+    return this.parsedWidgetProps.showCount || false;
+  }
+
+  /**
+   * Field size
+   */
+  _size: number | undefined;
+  get size(): number | undefined {
+    return this._size;
+  }
+
+  set size(value: number | undefined) {
+    this._size = value;
+  }
+
   /**
    * Must expand widget
    */
@@ -74,6 +90,9 @@ class Text extends Field {
         this.translatable = !!(
           props.translate === "True" || props.translate === true
         );
+      }
+      if (props.size) {
+        this.size = parseInt(props.size);
       }
     }
   }

--- a/src/spec/Char.spec.ts
+++ b/src/spec/Char.spec.ts
@@ -77,4 +77,35 @@ describe("A Char", () => {
 
     expect(widget.tooltip).toBe("This is a help field");
   });
+  describe("shouCount property", () => {
+    it("shoud default to false if is not defined", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "char1",
+      };
+      const widget = widgetFactory.createWidget("char", props);
+
+      expect(widget.showCount).toBe(false);
+    });
+    it("should be true if is defined as true", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "char1",
+        widget_props: "{'showCount': true}",
+      };
+      const widget = widgetFactory.createWidget("char", props);
+
+      expect(widget.showCount).toBe(true);
+    });
+    it("should be false if is defined as false", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "char1",
+        widget_props: "{'showCount': false}",
+      };
+      const widget = widgetFactory.createWidget("char", props);
+
+      expect(widget.showCount).toBe(false);
+    });
+  });
 });

--- a/src/spec/Text.spec.ts
+++ b/src/spec/Text.spec.ts
@@ -1,0 +1,67 @@
+import WidgetFactory from "../WidgetFactory";
+import { it, expect, describe } from "vitest";
+
+describe("A Text field", () => {
+  describe("show count properly", () => {
+    it("should be false as default", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "text1",
+      };
+      const widget = widgetFactory.createWidget("text", props);
+
+      expect(widget.showCount).toBe(false);
+    });
+    it("should be true when set", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "text1",
+        widget_props: "{'showCount': true}",
+      };
+      const widget = widgetFactory.createWidget("text", props);
+
+      expect(widget.showCount).toBe(true);
+    });
+    it("should be false when set", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "text1",
+        widget_props: "{'showCount': false}",
+      };
+      const widget = widgetFactory.createWidget("text", props);
+
+      expect(widget.showCount).toBe(false);
+    });
+  });
+  describe("size property", () => {
+    it("should be undefined as default", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "text1",
+      };
+      const widget = widgetFactory.createWidget("text", props);
+
+      expect(widget.size).toBe(undefined);
+    });
+    it("should be set if is an string", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "text1",
+        size: "256",
+      };
+      const widget = widgetFactory.createWidget("text", props);
+
+      expect(widget.size).toBe(256);
+    });
+    it("should be set if is a number", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "text1",
+        size: 256,
+      };
+      const widget = widgetFactory.createWidget("text", props);
+
+      expect(widget.size).toBe(256);
+    });
+  });
+});


### PR DESCRIPTION
Allow to showCount in char fields and text fields

## Char

```xml
<field name="char_field" widget_props="{'showCount': true}" />
```

## Text

```xml
<field name="text_field" widget_props="{'showCount': true}" />
```

If we want to put a *soft (front end)* limitation we can add `size` attribute to add a limit

```xml
<field name="text_field" size="140" widget_props="{'showCount': true}" />
```