### PR TITLE
Allow to define how y axis will work with min and max values

### DIFF
--- a/src/Graph/Graph.ts
+++ b/src/Graph/Graph.ts
@@ -1,6 +1,7 @@
 import { ParsedNode } from "../helpers/nodeParser";
 
 export type GraphType = "indicator" | "indicatorField" | "line" | "bar" | "pie";
+export type RangeType = "auto" | "full";
 
 export class Graph {
   _string: string | null = null;
@@ -23,11 +24,22 @@ export class Graph {
     return this._interval;
   }
 
+  _y_range: RangeType = "full";
+  get y_range(): RangeType {
+    return this._y_range;
+  }
+
   constructor(element: ParsedNode) {
     this._string = element.attributes.string || null;
     this._timerange = element.attributes.timerange || null;
     if (element.attributes.interval) {
       this._interval = parseInt(element.attributes.interval);
+    }
+    if (element.attributes.y_range) {
+      const range = element.attributes.y_range;
+      if (range === "auto" || range === "full") {
+        this._y_range = range;
+      }
     }
   }
 }


### PR DESCRIPTION
## Related

- https://github.com/gisce/webclient/issues/495
- Needs: https://github.com/gisce/erp/pull/21004

Now we can define if y axis should range all values: `full` or only the range with data `auto`. Default value is `full`.

```xml
<graph type="line" timerange="hour" y_range="auto">
  <field name="timestamp" axis="x" />
  <field name="v1" operator="+" axis="y" />
</graph>
```