### PR TITLE
update gisce/conscheck to v1.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@gisce/ooui",
       "version": "2.9.2",
       "dependencies": {
-        "@gisce/conscheck": "1.0.9",
+        "@gisce/conscheck": "1.0.11",
         "html-entities": "^2.3.3",
         "moment": "^2.29.3",
         "txml": "^5.1.1"
@@ -1133,9 +1133,9 @@
       }
     },
     "node_modules/@gisce/conscheck": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@gisce/conscheck/-/conscheck-1.0.9.tgz",
-      "integrity": "sha512-lEC0ShBY/klknvK1dZqRz4RIJxCuI0UJOI8KQMI/os+48U3qtpE+1pGQbxywhmNHVssKQRo2qOwDRu+zNZm6ag==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@gisce/conscheck/-/conscheck-1.0.11.tgz",
+      "integrity": "sha512-plKSVcByDWdvcVcNc5P5lT3dSo5KbxOX0AN+WTn5FQJ6tfXEv8RssTFwrGJ/7oJAArzLqhbdkshAIH3zyLyS8Q==",
       "engines": {
         "node": "20.5.0"
       }
@@ -14324,9 +14324,9 @@
       }
     },
     "@gisce/conscheck": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@gisce/conscheck/-/conscheck-1.0.9.tgz",
-      "integrity": "sha512-lEC0ShBY/klknvK1dZqRz4RIJxCuI0UJOI8KQMI/os+48U3qtpE+1pGQbxywhmNHVssKQRo2qOwDRu+zNZm6ag=="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@gisce/conscheck/-/conscheck-1.0.11.tgz",
+      "integrity": "sha512-plKSVcByDWdvcVcNc5P5lT3dSo5KbxOX0AN+WTn5FQJ6tfXEv8RssTFwrGJ/7oJAArzLqhbdkshAIH3zyLyS8Q=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.11",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "analyze": "npx vite-bundle-visualizer"
   },
   "dependencies": {
-    "@gisce/conscheck": "1.0.9",
+    "@gisce/conscheck": "1.0.11",
     "html-entities": "^2.3.3",
     "moment": "^2.29.3",
     "txml": "^5.1.1"


### PR DESCRIPTION
This PR updates [gisce/conscheck](https://github.com/gisce/conscheck) to [v1.0.11](https://github.com/gisce/conscheck/releases/tag/v1.0.11).