### PR TITLE
feat(alert): allow to add button actions to alert

### DIFF
--- a/src/Alert.ts
+++ b/src/Alert.ts
@@ -1,8 +1,9 @@
-import Field from "./Field";
+import ContainerWidget from "./ContainerWidget";
+import Button from "./Button";
 
 type AlertType = "success" | "warning" | "info" | "error" | undefined;
 
-class Alert extends Field {
+class Alert extends ContainerWidget {
   /**
    * Alert type
    */
@@ -42,10 +43,13 @@ class Alert extends Field {
     this._icon = value;
   }
 
+  get buttons(): Button[] {
+    return this._container.rows.flat().filter((b) => !b.invisible) as Button[];
+  }
+
   constructor(props: any) {
     super(props);
     if (props) {
-      this._nolabel = true;
       if (props.alert_type) {
         this._alertType = props.alert_type;
       }


### PR DESCRIPTION
Allow to add actions buttons to alert widget

```xml
<alert alert_type="info" title="Atención" text="Debes ir a la pestaña SIPS y pulsar el botón">
    <button type="object" string="Descarregar SIPS" icon="download" name="download_sips_ps_button"/>
</alert>