### PR TITLE
Add Email widget

### DIFF
--- a/src/Email.ts
+++ b/src/Email.ts
@@ -1,0 +1,35 @@
+import Field from "./Field";
+
+class Email extends Field {
+  _multi: boolean = false;
+  get multi(): boolean {
+    return this._multi;
+  }
+
+  set multi(value: boolean) {
+    this._multi = value;
+  }
+
+  _size: number | undefined;
+  get size(): number | undefined {
+    return this._size;
+  }
+
+  set size(value: number | undefined) {
+    this._size = value;
+  }
+
+  constructor(props: any) {
+    super(props);
+    if (props) {
+      if (props.size) {
+        this.size = props.size;
+      }
+    }
+    if (this.parsedWidgetProps.multi) {
+      this.multi = this.parsedWidgetProps.multi;
+    }
+  }
+}
+
+export default Email;

--- a/src/Widget.ts
+++ b/src/Widget.ts
@@ -161,12 +161,16 @@ abstract class Widget {
         }
       }
       if (props.widget_props) {
-        try {
-          this._parsedWidgetProps = JSON.parse(
-            props.widget_props.replace(/'/g, '"'),
-          );
-        } catch (err) {
-          console.error("Error parsing widget_props");
+        if (typeof props.widget_props === "string") {
+          try {
+            this._parsedWidgetProps = JSON.parse(
+              props.widget_props.replace(/'/g, '"'),
+            );
+          } catch (err) {
+            console.error("Error parsing widget_props");
+          }
+        } else {
+          this._parsedWidgetProps = props.widget_props;
         }
       }
       if (props.key) {

--- a/src/WidgetFactory.ts
+++ b/src/WidgetFactory.ts
@@ -39,6 +39,7 @@ import Time from "./Time";
 import Alert from "./Alert";
 import Comments from "./Comments";
 import JSONField from "./JSONField";
+import Email from "./Email";
 
 class WidgetFactory {
   /**
@@ -117,7 +118,7 @@ class WidgetFactory {
         this._widgetClass = Char;
         break;
       case "email":
-        this._widgetClass = Char;
+        this._widgetClass = Email;
         break;
       case "reference":
         this._widgetClass = Reference;

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ import HTMLPreview from "./HTMLPreview";
 import Alert from "./Alert";
 import JSONField from "./JSONField";
 import Comments from "./Comments";
+import Email from "./Email";
 
 import {
   Graph,
@@ -138,4 +139,5 @@ export {
   MinMaxValues,
   Comments,
   JSONField,
+  Email,
 };

--- a/src/spec/Email.spec.ts
+++ b/src/spec/Email.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import Email from "../Email";
+
+describe("Email", () => {
+  it("should initialize with default values", () => {
+    const email = new Email({});
+    expect(email.multi).toBe(false);
+    expect(email.size).toBeUndefined();
+  });
+
+  it("should set multi property correctly from widget_props", () => {
+    const email = new Email({ widget_props: { multi: true } });
+    expect(email.multi).toBe(true);
+  });
+
+  it("should set size property correctly", () => {
+    const email = new Email({ size: 10 });
+    expect(email.size).toBe(10);
+  });
+
+  it("should update multi property", () => {
+    const email = new Email({});
+    email.multi = true;
+    expect(email.multi).toBe(true);
+  });
+
+  it("should update size property", () => {
+    const email = new Email({});
+    email.size = 20;
+    expect(email.size).toBe(20);
+  });
+});

--- a/src/spec/Form.spec.ts
+++ b/src/spec/Form.spec.ts
@@ -3,6 +3,7 @@ import Group from "../Group";
 import Notebook from "../Notebook";
 import Page from "../Page";
 import Char from "../Char";
+import Email from "../Email";
 import Label from "../Label";
 import Field from "../Field";
 import Reference from "../Reference";
@@ -278,7 +279,7 @@ describe("A Form", () => {
     form.parse(XML_VIEW_FORM);
     const emailField = form.findById("email") as Field;
     expect(emailField.type).toBe("email");
-    expect(emailField).toBeInstanceOf(Char);
+    expect(emailField).toBeInstanceOf(Email);
     expect(emailField.fieldType).toBe("char");
   });
 


### PR DESCRIPTION
- No existia la classe `Email` com a tal, fins ara es feia servir `Char`.
- Aprofitem per afegir la propietat `multi` per si es poden entrar més d'un email