### PR TITLE
Allow loading in Page and Group components

### DIFF
--- a/src/Group.ts
+++ b/src/Group.ts
@@ -1,6 +1,6 @@
-import ContainerWidget from "./ContainerWidget";
+import Spinner from "./Spinner";
 
-class Group extends ContainerWidget {
+class Group extends Spinner {
   _icon: string | null = null;
   get icon(): string | null {
     return this._icon;

--- a/src/Page.ts
+++ b/src/Page.ts
@@ -1,6 +1,6 @@
-import ContainerWidget from "./ContainerWidget";
+import Spinner from "./Spinner";
 
-class Page extends ContainerWidget {
+class Page extends Spinner {
   _icon: string | null = null;
   get icon(): string | null {
     return this._icon;

--- a/src/spec/Group.spec.ts
+++ b/src/spec/Group.spec.ts
@@ -40,4 +40,23 @@ describe("A Group", () => {
     const widget = widgetFactory.createWidget("group", props);
     expect(widget.icon).toEqual("home");
   });
+  describe("working as a spinner", () => {
+    it("should be loading false as default", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        string: "A group",
+      };
+      const widget = widgetFactory.createWidget("group", props);
+      expect(widget.loading).toBe(false);
+    });
+    it("should be loading true if set", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        string: "A group",
+        loading: true,
+      };
+      const widget = widgetFactory.createWidget("group", props);
+      expect(widget.loading).toBe(true);
+    });
+  });
 });

--- a/src/spec/Page.spec.ts
+++ b/src/spec/Page.spec.ts
@@ -14,4 +14,23 @@ describe("A Page", () => {
     expect(widget.label).toBe("Page 1");
     expect(widget.icon).toBe("home");
   });
+  describe("working as a Spinner", () => {
+    it("should have loading to be false by default", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        string: "Page 1",
+      };
+      const widget = widgetFactory.createWidget("page", props);
+      expect(widget.loading).toBe(false);
+    });
+    it("should allow setting loading to true", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        string: "Page 1",
+        loading: true,
+      };
+      const widget = widgetFactory.createWidget("page", props);
+      expect(widget.loading).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
This pull request includes changes to refactor the `Group` and `Page` classes to extend from the `Spinner` class instead of `ContainerWidget`, and updates the corresponding tests to verify the new behavior. The most important changes include modifying the class inheritance and adding tests to validate the `loading` property.

Class inheritance changes:

* [`src/Group.ts`](diffhunk://#diff-e295ebec09ec83dfb098aa7a84a7c6bdb6f1c70db71b98da9962b6be4bbf0911L1-R3): Changed the `Group` class to extend from `Spinner` instead of `ContainerWidget`.
* [`src/Page.ts`](diffhunk://#diff-4d8b39b1dfaa4cb592b85a9ff76806e3b4a81bd04f9aed005fd26a97c50b2f8dL1-R3): Changed the `Page` class to extend from `Spinner` instead of `ContainerWidget`.

Test updates:

* [`src/spec/Group.spec.ts`](diffhunk://#diff-b5e319e1a3e9a7e6ef76a4d2521eb0031980ef938d686d177b25bd289678f80aR43-R61): Added tests to verify the `loading` property behavior in the `Group` class.
* [`src/spec/Page.spec.ts`](diffhunk://#diff-b4a6f3f262f3dca2f57528579be7f89bc428ae6e70cdab93b1f7041d01851099R17-R35): Added tests to verify the `loading` property behavior in the `Page` class.