### PR TITLE
feat: move fieldType to widget when we use widgets as fields

### DIFF
--- a/src/Field.ts
+++ b/src/Field.ts
@@ -117,14 +117,6 @@ class Field extends Widget {
     this._selectionValues = value;
   }
 
-  /**
-   * Base type of the field
-   */
-  _fieldType: string = "";
-  get fieldType(): string {
-    return this._fieldType;
-  }
-
   constructor(props: any) {
     super(props);
 
@@ -134,10 +126,6 @@ class Field extends Widget {
     if (props) {
       if (props.name) {
         this._id = props.name;
-      }
-
-      if (props.type) {
-        this._fieldType = props.fieldsWidgetType;
       }
 
       if (props.activated) {

--- a/src/Widget.ts
+++ b/src/Widget.ts
@@ -115,6 +115,14 @@ abstract class Widget {
     this._isFunction = value;
   }
 
+  /**
+   * Base type of the field
+   */
+  _fieldType: string = "";
+  get fieldType(): string {
+    return this._fieldType;
+  }
+
   constructor(props?: any) {
     this._colspan = Widget._defaultColspan;
     this._invisible = false;
@@ -159,6 +167,9 @@ abstract class Widget {
         } else {
           this._domain = replaceEntities(props.domain);
         }
+      }
+      if (props.type) {
+        this._fieldType = props.fieldsWidgetType;
       }
       if (props.widget_props) {
         if (typeof props.widget_props === "string") {


### PR DESCRIPTION
This pull request involves refactoring the `Field` and `Widget` classes to improve code organization by moving the `_fieldType` property and its related logic from the `Field` class to the `Widget` class.

Refactoring changes:

* [`src/Field.ts`](diffhunk://#diff-562b9741146b51b41cb61e6f1dded5dd4e938dc803587f338f86a23b9d8dcbddL120-L127): Removed the `_fieldType` property and its getter method from the `Field` class. Additionally, removed the logic that sets `_fieldType` based on `props.type`. [[1]](diffhunk://#diff-562b9741146b51b41cb61e6f1dded5dd4e938dc803587f338f86a23b9d8dcbddL120-L127) [[2]](diffhunk://#diff-562b9741146b51b41cb61e6f1dded5dd4e938dc803587f338f86a23b9d8dcbddL139-L142)
* [`src/Widget.ts`](diffhunk://#diff-8bcecac280c3eb3018a21d64ea989f149e364555d180a59765e6aded5ef5fadbR118-R125): Added the `_fieldType` property and its getter method to the `Widget` class. Also, included the logic to set `_fieldType` based on `props.type`. [[1]](diffhunk://#diff-8bcecac280c3eb3018a21d64ea989f149e364555d180a59765e6aded5ef5fadbR118-R125) [[2]](diffhunk://#diff-8bcecac280c3eb3018a21d64ea989f149e364555d180a59765e6aded5ef5fadbR171-R173)