### PR TITLE
Add new carousel widget container

### DIFF
--- a/src/Carousel.ts
+++ b/src/Carousel.ts
@@ -1,7 +1,9 @@
 import ContainerWidget from "./ContainerWidget";
+import Group from "./Group";
+import { parseBoolAttribute } from "./helpers/nodeParser";
 
 class Carousel extends ContainerWidget {
-  _autoPlay = false;
+  _autoPlay = true;
 
   get autoPlay(): boolean {
     return this._autoPlay;
@@ -11,11 +13,15 @@ class Carousel extends ContainerWidget {
     this._autoPlay = value;
   }
 
+  get items(): Group[] {
+    return this._container.rows.flat().filter((g) => !g.invisible) as Group[];
+  }
+
   constructor(props?: any) {
     super(props);
     if (props) {
-      if (props.auto_play) {
-        this._autoPlay = props.auto_play;
+      if ("auto_play" in props) {
+        this._autoPlay = parseBoolAttribute(props.auto_play);
       }
     }
   }

--- a/src/Carousel.ts
+++ b/src/Carousel.ts
@@ -1,0 +1,24 @@
+import ContainerWidget from "./ContainerWidget";
+
+class Carousel extends ContainerWidget {
+  _autoPlay = false;
+
+  get autoPlay(): boolean {
+    return this._autoPlay;
+  }
+
+  set autoPlay(value: boolean) {
+    this._autoPlay = value;
+  }
+
+  constructor(props?: any) {
+    super(props);
+    if (props) {
+      if (props.auto_play) {
+        this._autoPlay = props.auto_play;
+      }
+    }
+  }
+}
+
+export default Carousel;

--- a/src/WidgetFactory.ts
+++ b/src/WidgetFactory.ts
@@ -41,6 +41,7 @@ import Comments from "./Comments";
 import JSONField from "./JSONField";
 import Email from "./Email";
 import Spinner from "./Spinner";
+import Carousel from "./Carousel";
 
 class WidgetFactory {
   /**
@@ -183,6 +184,9 @@ class WidgetFactory {
         break;
       case "spinner":
         this._widgetClass = Spinner;
+        break;
+      case "carousel":
+        this._widgetClass = Carousel;
         break;
       default:
         break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ import JSONField from "./JSONField";
 import Comments from "./Comments";
 import Email from "./Email";
 import Spinner from "./Spinner";
+import Carousel from "./Carousel";
 
 import {
   Graph,
@@ -142,4 +143,5 @@ export {
   JSONField,
   Email,
   Spinner,
+  Carousel,
 };

--- a/src/spec/Carousel.spec.ts
+++ b/src/spec/Carousel.spec.ts
@@ -1,0 +1,32 @@
+import WidgetFactory from "../WidgetFactory";
+import Carousel from "../Carousel";
+import { it, expect, describe } from "vitest";
+
+describe("A Carousel", () => {
+  it("should have an id corresponding to field name", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "carousel",
+    };
+
+    const widget = widgetFactory.createWidget("carousel", props);
+    expect(widget).toBeInstanceOf(Carousel);
+  });
+  it("should have autoPlay as false by default", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "carousel",
+    };
+    const widget = widgetFactory.createWidget("carousel", props);
+    expect(widget.autoPlay).toBe(false);
+  });
+  it("should allow autoPlay to be set", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "carousel",
+      auto_play: true,
+    };
+    const widget = widgetFactory.createWidget("carousel", props);
+    expect(widget.autoPlay).toBe(true);
+  });
+});

--- a/src/spec/Carousel.spec.ts
+++ b/src/spec/Carousel.spec.ts
@@ -1,4 +1,5 @@
 import WidgetFactory from "../WidgetFactory";
+import Form from "../Form";
 import Carousel from "../Carousel";
 import { it, expect, describe } from "vitest";
 
@@ -12,21 +13,63 @@ describe("A Carousel", () => {
     const widget = widgetFactory.createWidget("carousel", props);
     expect(widget).toBeInstanceOf(Carousel);
   });
-  it("should have autoPlay as false by default", () => {
+  it("should have autoPlay as true by default", () => {
     const widgetFactory = new WidgetFactory();
     const props = {
       name: "carousel",
     };
     const widget = widgetFactory.createWidget("carousel", props);
-    expect(widget.autoPlay).toBe(false);
+    expect(widget.autoPlay).toBe(true);
   });
   it("should allow autoPlay to be set", () => {
     const widgetFactory = new WidgetFactory();
     const props = {
       name: "carousel",
-      auto_play: true,
+      auto_play: false,
     };
     const widget = widgetFactory.createWidget("carousel", props);
-    expect(widget.autoPlay).toBe(true);
+    expect(widget.autoPlay).toBe(false);
+  });
+  it("should have items with the first childs group items", () => {
+    const xml = `
+      <form>
+        <carousel name="carousel">
+            <group string="Group 1">
+                <field name="field1" string="Field 1" />
+            </group>
+            <group string="Group 2">
+                <field name="field2" string="Field 2" />
+                <group string="Group 3">
+                    <field name="field3" string="Field 3" />
+                </group>
+            </group>
+        </carousel>
+      </form>
+    `;
+    const fields = {
+      field1: {
+        string: "Field 1",
+        type: "char",
+        size: 10,
+      },
+      field2: {
+        string: "Field 2",
+        type: "char",
+        size: 10,
+      },
+      field3: {
+        string: "Field 3",
+        type: "char",
+        size: 10,
+      },
+    };
+
+    const form = new Form(fields);
+    form.parse(xml);
+    const carousel = form.findById("carousel") as Carousel;
+    expect(carousel).toBeInstanceOf(Carousel);
+    expect(carousel.items.length).toBe(2);
+    expect(carousel.items[0].label).toBe("Group 1");
+    expect(carousel.items[1].label).toBe("Group 2");
   });
 });


### PR DESCRIPTION
This pull request introduces a new `Carousel` widget to the codebase, along with the necessary integration and tests. The main changes include the implementation of the `Carousel` class, updates to the `WidgetFactory` to support the new widget, and the addition of tests to ensure the `Carousel` functions correctly.

### Implementation of `Carousel` widget:

* [`src/Carousel.ts`](diffhunk://#diff-23c62db57734d9d840b861d5c8d98c1dea18e65a723d4a10bb79d206c0e5b0ccR1-R30): Added the `Carousel` class, which extends `ContainerWidget` and includes properties and methods for `autoPlay` and `items`. The constructor allows setting `autoPlay` via properties.

### Integration with `WidgetFactory`:

* [`src/WidgetFactory.ts`](diffhunk://#diff-e24854d27ab93ed8dcbbb22c3c95ba2dd02f03d034d495207f1d7901951f98cdR44): Imported the `Carousel` class and updated the `WidgetFactory` to create a `Carousel` widget when the type is "carousel". [[1]](diffhunk://#diff-e24854d27ab93ed8dcbbb22c3c95ba2dd02f03d034d495207f1d7901951f98cdR44) [[2]](diffhunk://#diff-e24854d27ab93ed8dcbbb22c3c95ba2dd02f03d034d495207f1d7901951f98cdR188-R190)

### Exporting the `Carousel` widget:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R56): Imported and exported the `Carousel` class to make it available for use in other parts of the application. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R56) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R146)

### Testing the `Carousel` widget:

* [`src/spec/Carousel.spec.ts`](diffhunk://#diff-61ff70ad3295a91c32807691d9a3a7fc39d414e8051fece9bffb86cc544a3c43R1-R75): Added tests for the `Carousel` widget to verify its creation, default `autoPlay` value, ability to set `autoPlay`, and correct handling of items within groups.