### PR TITLE
Add height to the group

### DIFF
--- a/src/Group.ts
+++ b/src/Group.ts
@@ -10,11 +10,28 @@ class Group extends Spinner {
     this._icon = value;
   }
 
+  _height: number | undefined;
+  get height(): number | undefined {
+    return this._height;
+  }
+
+  set height(value: number | undefined) {
+    this._height = value;
+  }
+
   constructor(props: any) {
     super(props);
     if (props) {
       if (props.icon) {
         this._icon = props.icon;
+      }
+      if (props.height) {
+        try {
+          this._height = parseInt(props.height);
+        } catch (e) {
+          console.log("Error parsing height");
+          this._height = undefined;
+        }
       }
     }
   }

--- a/src/spec/Group.spec.ts
+++ b/src/spec/Group.spec.ts
@@ -58,5 +58,14 @@ describe("A Group", () => {
       const widget = widgetFactory.createWidget("group", props);
       expect(widget.loading).toBe(true);
     });
+    it("should allow to set height", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        string: "A group",
+        height: 100,
+      };
+      const widget = widgetFactory.createWidget("group", props);
+      expect(widget.height).toBe(100);
+    });
   });
 });


### PR DESCRIPTION
This pull request introduces a new `height` property to the `Group` class in `src/Group.ts` and includes corresponding unit tests to ensure the property is set correctly. The main changes include adding getter and setter methods for the `height` property and updating the constructor to handle the new property.

Changes to `Group` class:

* Added a `_height` property with getter and setter methods to the `Group` class in `src/Group.ts`.
* Updated the `Group` class constructor to parse and set the `height` property from the provided `props` object.

Unit tests:

* Added a new test case in `src/spec/Group.spec.ts` to verify that the `height` property can be set and retrieved correctly.