### PR TITLE
evaluateFieldComparison use index 0 of many2one

### DIFF
--- a/src/helpers/attributeParser.ts
+++ b/src/helpers/attributeParser.ts
@@ -76,9 +76,6 @@ const evaluateFieldComparison = ({
   expectedValue,
   fields = {},
 }: FieldComparisonParams & { fields: any }): FieldComparisonResult => {
-  if (fields?.fieldName?.type !== "many2one" && valueInObject) {
-    valueInObject = valueInObject[0];
-  }
   const result: FieldComparisonResult = {
     modifiedValueInObject: valueInObject,
     modifiedExpectedValue: null,
@@ -117,14 +114,18 @@ const evaluateFieldComparison = ({
   ) {
     result.modifiedExpectedValue = undefined;
   } else {
-    result.modifiedValueInObject =
-      result.modifiedValueInObject === undefined
-        ? false
-        : result.modifiedValueInObject;
-    result.modifiedValueInObject =
-      result.modifiedValueInObject === null
-        ? false
-        : result.modifiedValueInObject;
+    if (result.modifiedValueInObject === undefined) {
+      result.modifiedValueInObject = false;
+    } else if (
+      Array.isArray(result.modifiedValueInObject) &&
+      result.modifiedValueInObject[0] !== undefined
+    ) {
+      result.modifiedValueInObject = result.modifiedValueInObject[0];
+    }
+
+    if (result.modifiedValueInObject === null) {
+      result.modifiedValueInObject = false;
+    }
   }
 
   if (

--- a/src/helpers/attributeParser.ts
+++ b/src/helpers/attributeParser.ts
@@ -76,6 +76,9 @@ const evaluateFieldComparison = ({
   expectedValue,
   fields = {},
 }: FieldComparisonParams & { fields: any }): FieldComparisonResult => {
+  if (fields?.fieldName?.type !== "many2one" && valueInObject) {
+    valueInObject = valueInObject[0];
+  }
   const result: FieldComparisonResult = {
     modifiedValueInObject: valueInObject,
     modifiedExpectedValue: null,

--- a/src/spec/attributeParser.spec.ts
+++ b/src/spec/attributeParser.spec.ts
@@ -479,6 +479,20 @@ describe("An Attribute Parser", () => {
       });
       expect(evaluatedAttrs.invisible).toBeTruthy();
     });
+    it("should properly use the id of a many2one value", () => {
+      const tagAttributes = {
+        json_attrs:
+          '{"invisible":{"condition":"AND","rules":[{"field":"autoconsum_id","operator":"=","value":10}]}}',
+      };
+      const values = { autoconsum_id: [10, "Autoconsum"] };
+      const evaluatedAttrs = evaluateAttributes({
+        tagAttributes,
+        values,
+        fields,
+        fallbackMode: false,
+      });
+      expect(evaluatedAttrs.invisible).toBeTruthy();
+    });
     it("should properly parse a many2one attribute with undefined value", () => {
       const tagAttributes = {
         json_attrs:


### PR DESCRIPTION
This pull request includes changes to the `attributeParser` helper and its corresponding tests to ensure proper handling of `many2one` field types. The most important changes include modifying the `evaluateFieldComparison` function to handle `many2one` values correctly and adding a new test case to verify this behavior.

Improvements to `attributeParser` helper:

* [`src/helpers/attributeParser.ts`](diffhunk://#diff-c1cc2ae0977c485ca3b8d0e38f0ef01ec33da818b9d905d4a9eed9d04c014063R79-R81): Modified the `evaluateFieldComparison` function to check if the field type is `many2one` and adjust the `valueInObject` accordingly.

Enhancements to test coverage:

* [`src/spec/attributeParser.spec.ts`](diffhunk://#diff-daeec99fd4e948cd3887ce03d0895fb6e8ce7a5a69d5de82f74dc967ebdaae15R482-R495): Added a new test case to ensure the `evaluateAttributes` function properly uses the ID of a `many2one` value.