### PR TITLE
Tag: allow colorField to define color for tag

### DIFF
--- a/src/Field.ts
+++ b/src/Field.ts
@@ -147,6 +147,11 @@ class Field extends Widget {
     super.readOnly = value;
   }
 
+  _raw_props: any;
+  get raw_props(): any {
+    return this._raw_props;
+  }
+
   constructor(props: any) {
     super(props);
 
@@ -154,6 +159,7 @@ class Field extends Widget {
     this._activated = true;
 
     if (props) {
+      this._raw_props = props;
       if (props.name) {
         this._id = props.name;
       }

--- a/src/Tag.ts
+++ b/src/Tag.ts
@@ -7,6 +7,10 @@ class Tag extends Selection {
   get colors(): any | "auto" {
     return this._parsedWidgetProps.colors || {};
   }
+
+  get colorField(): string | null {
+    return this._parsedWidgetProps?.colorField || null;
+  }
 }
 
 export default Tag;

--- a/src/spec/Tag.spec.ts
+++ b/src/spec/Tag.spec.ts
@@ -44,4 +44,26 @@ describe("A Tag widget", () => {
       expect(widget.colors).toStrictEqual("auto");
     });
   });
+
+  describe("colorField property", () => {
+    it("should have default colorField to null", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "status",
+      };
+      const widget = widgetFactory.createWidget("tag", props);
+
+      expect(widget.colorField).toBeNull();
+    });
+    it("should parse colorField property", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "status",
+        widget_props: '{"colorField": "color"}',
+      };
+      const widget = widgetFactory.createWidget("tag", props);
+
+      expect(widget.colorField).toBe("color");
+    });
+  });
 });


### PR DESCRIPTION
This pull request includes changes to the `Field` and `Tag` classes to add new properties and methods, as well as updates to the test suite for the `Tag` class to cover the new functionality.

### Enhancements to `Field` class:

* Added a private `_raw_props` property and a corresponding `raw_props` getter to store the raw properties passed to the constructor. (`src/Field.ts`)

### Enhancements to `Tag` class:

* Added a `colorField` getter to retrieve the `colorField` property from the widget properties. (`src/Tag.ts`)

### Updates to `Tag` class tests:

* Added tests to ensure the `colorField` property is correctly set to `null` by default and properly parsed when provided. (`src/spec/Tag.spec.ts`)