### PR TITLE
Allow to hide folder

### DIFF
--- a/src/Many2one.ts
+++ b/src/Many2one.ts
@@ -32,6 +32,14 @@ class Many2one extends Field {
     return this.parsedWidgetProps.showFolder ?? true;
   }
 
+  get showSearch(): boolean {
+    return this.parsedWidgetProps.showSearch ?? true;
+  }
+
+  get showMenu(): boolean {
+    return this.parsedWidgetProps.showMenu ?? true;
+  }
+
   constructor(props: any) {
     super(props);
 

--- a/src/Many2one.ts
+++ b/src/Many2one.ts
@@ -28,6 +28,10 @@ class Many2one extends Field {
     this._relation = value;
   }
 
+  get showFolder(): boolean {
+    return this.parsedWidgetProps.showFolder ?? true;
+  }
+
   constructor(props: any) {
     super(props);
 

--- a/src/spec/Many2one.spec.ts
+++ b/src/spec/Many2one.spec.ts
@@ -34,23 +34,63 @@ describe("A Many2one", () => {
 
     expect(widget.relation).toBe("res.country");
   });
-  it("should default showFolder to true", () => {
-    const widgetFactory = new WidgetFactory();
-    const props = {
-      name: "many2one1",
-      relation: "res.country",
-    };
-    const widget = widgetFactory.createWidget("many2one", props);
-    expect(widget.showFolder).toBe(true);
-  });
-  it("should have a property to hide the folder through widget props", () => {
-    const widgetFactory = new WidgetFactory();
-    const props = {
-      name: "many2one1",
-      relation: "res.country",
-      widget_props: "{'showFolder': false}",
-    };
-    const widget = widgetFactory.createWidget("many2one", props);
-    expect(widget.showFolder).toBe(false);
+  describe("Hiding buttons", () => {
+    it("should default showFolder to true", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "many2one1",
+        relation: "res.country",
+      };
+      const widget = widgetFactory.createWidget("many2one", props);
+      expect(widget.showFolder).toBe(true);
+    });
+    it("should have a property to hide the folder through widget props", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "many2one1",
+        relation: "res.country",
+        widget_props: "{'showFolder': false}",
+      };
+      const widget = widgetFactory.createWidget("many2one", props);
+      expect(widget.showFolder).toBe(false);
+    });
+    it("should default showSearch to true", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "many2one1",
+        relation: "res.country",
+      };
+      const widget = widgetFactory.createWidget("many2one", props);
+      expect(widget.showSearch).toBe(true);
+    });
+    it("should have a property to hide the search button through widget props", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "many2one1",
+        relation: "res.country",
+        widget_props: "{'showSearch': false}",
+      };
+      const widget = widgetFactory.createWidget("many2one", props);
+      expect(widget.showSearch).toBe(false);
+    });
+    it("should default showMenu to true", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "many2one1",
+        relation: "res.country",
+      };
+      const widget = widgetFactory.createWidget("many2one", props);
+      expect(widget.showMenu).toBe(true);
+    });
+    it("should have a property to hide the menu through widget props", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "many2one1",
+        relation: "res.country",
+        widget_props: "{'showMenu': false}",
+      };
+      const widget = widgetFactory.createWidget("many2one", props);
+      expect(widget.showMenu).toBe(false);
+    });
   });
 });

--- a/src/spec/Many2one.spec.ts
+++ b/src/spec/Many2one.spec.ts
@@ -34,4 +34,23 @@ describe("A Many2one", () => {
 
     expect(widget.relation).toBe("res.country");
   });
+  it("should default showFolder to true", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "many2one1",
+      relation: "res.country",
+    };
+    const widget = widgetFactory.createWidget("many2one", props);
+    expect(widget.showFolder).toBe(true);
+  });
+  it("should have a property to hide the folder through widget props", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "many2one1",
+      relation: "res.country",
+      widget_props: "{'showFolder': false}",
+    };
+    const widget = widgetFactory.createWidget("many2one", props);
+    expect(widget.showFolder).toBe(false);
+  });
 });


### PR DESCRIPTION
This pull request introduces a new `showFolder` property to the `Many2one` class, allowing control over whether a folder is displayed, and adds corresponding unit tests to ensure its functionality.

### Enhancements to `Many2one` class:
* Added a `showFolder` getter to the `Many2one` class, which defaults to `true` but can be overridden via `parsedWidgetProps`. (`src/Many2one.ts`, [src/Many2one.tsR31-R34](diffhunk://#diff-4c00e9f9848f1ae89fbcb2e0c56c0dfb354baeee00d91354dd26c8018dc9a414R31-R34))

### Unit tests:
* Added a test to verify that `showFolder` defaults to `true` if not specified in `widget_props`. (`src/spec/Many2one.spec.ts`, [src/spec/Many2one.spec.tsR37-R55](diffhunk://#diff-e73bc86bf1bb2283419b0b6b02b26ee82ad45870fa8e1e74fc334cab50cd4c68R37-R55))
* Added a test to confirm that `showFolder` can be set to `false` through `widget_props`. (`src/spec/Many2one.spec.ts`, [src/spec/Many2one.spec.tsR37-R55](diffhunk://#diff-e73bc86bf1bb2283419b0b6b02b26ee82ad45870fa8e1e74fc334cab50cd4c68R37-R55))