### PR TITLE
Widget: new attribute isSortable

### DIFF
--- a/src/Widget.ts
+++ b/src/Widget.ts
@@ -116,6 +116,11 @@ abstract class Widget {
     this._isFunction = value;
   }
 
+  _isSortable: boolean = false;
+  get isSortable(): boolean {
+    return this._isSortable;
+  }
+
   /**
    * Base type of the field
    */
@@ -168,6 +173,9 @@ abstract class Widget {
       }
       if (props.is_function) {
         this._isFunction = props.is_function;
+      }
+      if (props.is_sortable) {
+        this._isSortable = props.is_sortable;
       }
     }
   }


### PR DESCRIPTION
This pull request introduces a new `isSortable` property to the `Widget` class in `src/Widget.ts`. The changes ensure that widgets can now have a sortable attribute, which is both initialized and accessible.

### New `isSortable` property in `Widget` class:

* Added a private `_isSortable` field with a default value of `false` and a corresponding `isSortable` getter to expose its value. (`[src/Widget.tsR119-R123](diffhunk://#diff-8bcecac280c3eb3018a21d64ea989f149e364555d180a59765e6aded5ef5fadbR119-R123)`)
* Updated the constructor to initialize `_isSortable` based on the `props.is_sortable` property if provided. (`[src/Widget.tsR177-R179](diffhunk://#diff-8bcecac280c3eb3018a21d64ea989f149e364555d180a59765e6aded5ef5fadbR177-R179)`)