### PR TITLE
feat: add QRCode widget with width, border and showValue properties

### DIFF
--- a/src/QRCode.ts
+++ b/src/QRCode.ts
@@ -1,0 +1,21 @@
+import Field from "./Field";
+
+/**
+ * QRCode widget
+ */
+class QRCode extends Field {
+  get width(): number | undefined {
+    return this.parsedWidgetProps?.width;
+  }
+
+  get border(): boolean {
+    return this.parsedWidgetProps?.border ?? false;
+  }
+
+  get showValue(): boolean {
+    console.log(this.parsedWidgetProps);
+    return this.parsedWidgetProps?.showValue ?? false;
+  }
+}
+
+export default QRCode;

--- a/src/WidgetFactory.ts
+++ b/src/WidgetFactory.ts
@@ -43,6 +43,7 @@ import Email from "./Email";
 import Spinner from "./Spinner";
 import Carousel from "./Carousel";
 import ColorPicker from "./ColorPicker";
+import QRCode from "./QRCode";
 
 class WidgetFactory {
   /**
@@ -191,6 +192,9 @@ class WidgetFactory {
         break;
       case "colorPicker":
         this._widgetClass = ColorPicker;
+        break;
+      case "qrcode":
+        this._widgetClass = QRCode;
         break;
       default:
         break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ import Email from "./Email";
 import Spinner from "./Spinner";
 import Carousel from "./Carousel";
 import ColorPicker from "./ColorPicker";
+import QRCode from "./QRCode";
 
 import {
   Graph,
@@ -146,4 +147,5 @@ export {
   Spinner,
   Carousel,
   ColorPicker,
+  QRCode,
 };

--- a/src/spec/QRCode.spec.ts
+++ b/src/spec/QRCode.spec.ts
@@ -1,0 +1,127 @@
+import WidgetFactory from "../WidgetFactory";
+import QRCode from "../QRCode";
+import { it, expect, describe } from "vitest";
+
+describe("A QRCode", () => {
+  it("should have an id corresponding to field name", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "qrcode",
+    };
+
+    const widget = widgetFactory.createWidget("qrcode", props);
+    expect(widget).toBeInstanceOf(QRCode);
+  });
+
+  it("should properly set label", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "qrcode",
+      string: "QR Code caption",
+    };
+    const widget = widgetFactory.createWidget("qrcode", props);
+
+    expect(widget.label).toBe("QR Code caption");
+  });
+
+  describe("width property", () => {
+    it("should be undefined by default", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "qrcode",
+      };
+      const widget = widgetFactory.createWidget("qrcode", props);
+
+      expect(widget.width).toBeUndefined();
+    });
+
+    it("should return width when widget_props.width is set", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "qrcode",
+        widget_props: {
+          width: 200,
+        },
+      };
+      const widget = widgetFactory.createWidget("qrcode", props);
+
+      expect(widget.width).toBe(200);
+    });
+  });
+
+  describe("border property", () => {
+    it("should be false by default", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "qrcode",
+      };
+      const widget = widgetFactory.createWidget("qrcode", props);
+
+      expect(widget.border).toBe(false);
+    });
+
+    it("should be true when widget_props.border is true", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "qrcode",
+        widget_props: {
+          border: true,
+        },
+      };
+      const widget = widgetFactory.createWidget("qrcode", props);
+
+      expect(widget.border).toBe(true);
+    });
+
+    it("should be false when widget_props.border is false", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "qrcode",
+        widget_props: {
+          border: false,
+        },
+      };
+      const widget = widgetFactory.createWidget("qrcode", props);
+
+      expect(widget.border).toBe(false);
+    });
+  });
+
+  describe("showValue property", () => {
+    it("should be false by default", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "qrcode",
+      };
+      const widget = widgetFactory.createWidget("qrcode", props);
+
+      expect(widget.showValue).toBe(false);
+    });
+
+    it("should be true when widget_props.showValue is true", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "qrcode",
+        widget_props: {
+          showValue: true,
+        },
+      };
+      const widget = widgetFactory.createWidget("qrcode", props);
+
+      expect(widget.showValue).toBe(true);
+    });
+
+    it("should be false when widget_props.showValue is false", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        name: "qrcode",
+        widget_props: {
+          showValue: false,
+        },
+      };
+      const widget = widgetFactory.createWidget("qrcode", props);
+
+      expect(widget.showValue).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
This pull request adds a new `QRCode` widget to the codebase, integrates it with the widget factory, and provides comprehensive tests for its behavior. The main changes include implementing the `QRCode` class, updating the factory and exports to support it, and adding a dedicated test suite.

**New QRCode widget implementation and integration:**

* Added a new `QRCode` class in `QRCode.ts` that extends `Field` and provides `width`, `border`, and `showValue` properties based on parsed widget props.
* Registered the new `QRCode` widget type in `WidgetFactory`, allowing it to be created via the factory pattern. [[1]](diffhunk://#diff-e24854d27ab93ed8dcbbb22c3c95ba2dd02f03d034d495207f1d7901951f98cdR46) [[2]](diffhunk://#diff-e24854d27ab93ed8dcbbb22c3c95ba2dd02f03d034d495207f1d7901951f98cdR196-R198)
* Exported the `QRCode` widget from the main module in `index.ts` for external usage. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R58) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R150)

**Testing:**

* Added a new test suite `QRCode.spec.ts` to verify widget instantiation, label assignment, and the correct behavior of the `width`, `border`, and `showValue` properties under various scenarios.