### PR TITLE
feat: add Card container widget

### DIFF
--- a/src/Card.ts
+++ b/src/Card.ts
@@ -19,6 +19,19 @@ class Card extends Spinner {
     this._icon = value;
   }
 
+  /**
+   * Height of the card component
+   */
+  _height: number | undefined = undefined;
+
+  get height(): number | undefined {
+    return this._height;
+  }
+
+  set height(value: number | undefined) {
+    this._height = value;
+  }
+
   constructor(props: any) {
     super(props);
     if (props) {
@@ -27,6 +40,10 @@ class Card extends Spinner {
       }
       if (props.icon) {
         this._icon = props.icon;
+      }
+      if (props.height) {
+        const parsedHeight = parseInt(props.height);
+        this._height = isNaN(parsedHeight) ? undefined : parsedHeight;
       }
     }
   }

--- a/src/Card.ts
+++ b/src/Card.ts
@@ -1,0 +1,35 @@
+import Spinner from "./Spinner";
+
+class Card extends Spinner {
+  _title: string | null = null;
+  get title(): string | null {
+    return this._title;
+  }
+
+  set title(value: string | null) {
+    this._title = value;
+  }
+
+  _icon: string | null = null;
+  get icon(): string | null {
+    return this._icon;
+  }
+
+  set icon(value: string | null) {
+    this._icon = value;
+  }
+
+  constructor(props: any) {
+    super(props);
+    if (props) {
+      if (props.title) {
+        this._title = props.title;
+      }
+      if (props.icon) {
+        this._icon = props.icon;
+      }
+    }
+  }
+}
+
+export default Card;

--- a/src/WidgetFactory.ts
+++ b/src/WidgetFactory.ts
@@ -44,6 +44,7 @@ import Spinner from "./Spinner";
 import Carousel from "./Carousel";
 import ColorPicker from "./ColorPicker";
 import QRCode from "./QRCode";
+import Card from "./Card";
 
 class WidgetFactory {
   /**
@@ -61,6 +62,9 @@ class WidgetFactory {
         break;
       case "group":
         this._widgetClass = Group;
+        break;
+      case "card":
+        this._widgetClass = Card;
         break;
       case "label":
         this._widgetClass = Label;
@@ -223,6 +227,7 @@ class WidgetFactory {
       case "notebook":
       case "page":
       case "group":
+      case "card":
         return new this._widgetClass({ ...props, type: finalType });
       case "button":
         return new this._widgetClass({

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ import Spinner from "./Spinner";
 import Carousel from "./Carousel";
 import ColorPicker from "./ColorPicker";
 import QRCode from "./QRCode";
+import Card from "./Card";
 
 import {
   Graph,
@@ -148,4 +149,5 @@ export {
   Carousel,
   ColorPicker,
   QRCode,
+  Card,
 };

--- a/src/spec/Card.spec.ts
+++ b/src/spec/Card.spec.ts
@@ -49,6 +49,24 @@ describe("A Card", () => {
     const widget = widgetFactory.createWidget("card", props);
     expect(widget.title).toEqual("Card Title");
   });
+  it("can have a height property", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      title: "Card Title",
+      height: "200",
+    };
+    const widget = widgetFactory.createWidget("card", props);
+    expect(widget.height).toEqual(200);
+  });
+  it("should handle invalid height values", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      title: "Card Title",
+      height: "invalid",
+    };
+    const widget = widgetFactory.createWidget("card", props);
+    expect(widget.height).toBeUndefined();
+  });
   describe("working as a spinner", () => {
     it("should be loading false as default", () => {
       const widgetFactory = new WidgetFactory();

--- a/src/spec/Card.spec.ts
+++ b/src/spec/Card.spec.ts
@@ -1,0 +1,71 @@
+import Card from "../Card";
+import WidgetImpl from "./fixtures/WidgetImpl";
+import WidgetFactory from "../WidgetFactory";
+import { it, expect, describe } from "vitest";
+
+describe("A Card", () => {
+  it("should be constructed with 4 columns and a colspan of 4", () => {
+    const card4 = new Card({ col: 4, colspan: 4 });
+    expect(card4.colspan).toBe(4);
+    expect(card4.container.columns).toBe(4);
+  });
+  it("should be constructed with 6 columns and a colspan of 2", () => {
+    const card4 = new Card({ col: 6, colspan: 2 });
+    expect(card4.colspan).toBe(2);
+    expect(card4.container.columns).toBe(6);
+  });
+  it("should have 1 rows if 4 items", () => {
+    const card4 = new Card({ col: 4, colspan: 4 });
+    card4.container.addWidget(new WidgetImpl({ name: "1" }));
+    card4.container.addWidget(new WidgetImpl({ name: "2" }));
+    card4.container.addWidget(new WidgetImpl({ name: "3" }));
+    card4.container.addWidget(new WidgetImpl({ name: "4" }));
+    expect(card4.container.rows.length).toBe(1);
+  });
+  it("should have 2 rows if 5 items", () => {
+    const card4 = new Card({ col: 4, colspan: 4 });
+    card4.container.addWidget(new WidgetImpl({ name: "1" }));
+    card4.container.addWidget(new WidgetImpl({ name: "2" }));
+    card4.container.addWidget(new WidgetImpl({ name: "3" }));
+    card4.container.addWidget(new WidgetImpl({ name: "4" }));
+    card4.container.addWidget(new WidgetImpl({ name: "5" }));
+    expect(card4.container.rows.length).toBe(2);
+  });
+  it("can have an icon property", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      title: "General",
+      icon: "home",
+    };
+    const widget = widgetFactory.createWidget("card", props);
+    expect(widget.icon).toEqual("home");
+  });
+  it("can have a title property", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      title: "Card Title",
+      icon: "user",
+    };
+    const widget = widgetFactory.createWidget("card", props);
+    expect(widget.title).toEqual("Card Title");
+  });
+  describe("working as a spinner", () => {
+    it("should be loading false as default", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        title: "A card",
+      };
+      const widget = widgetFactory.createWidget("card", props);
+      expect(widget.loading).toBe(false);
+    });
+    it("should be loading true if set", () => {
+      const widgetFactory = new WidgetFactory();
+      const props = {
+        title: "A card",
+        loading: true,
+      };
+      const widget = widgetFactory.createWidget("card", props);
+      expect(widget.loading).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Add new Card widget as a container component with title and icon attributes.

- Create Card class extending Spinner
- Add title and icon properties
- Register Card in WidgetFactory
- Export Card from index
- Add comprehensive test suite in Card.spec.ts

The Card widget is similar to Group but uses title instead of label and is designed to be rendered with modern card-style UI components.