### PR TITLE
feat: add Icon component with name, size and color parameters

### DIFF
--- a/src/Icon.ts
+++ b/src/Icon.ts
@@ -1,0 +1,59 @@
+import Field from "./Field";
+
+class Icon extends Field {
+  /**
+   * Icon name
+   */
+  _name: string = "";
+  get name(): string {
+    return this._name;
+  }
+
+  set name(value: string) {
+    this._name = value;
+  }
+
+  /**
+   * Icon size
+   */
+  _size: number = 16;
+  get size(): number {
+    return this._size;
+  }
+
+  set size(value: number) {
+    this._size = value;
+  }
+
+  /**
+   * Icon color
+   */
+  _color: string = "";
+  get color(): string {
+    return this._color;
+  }
+
+  set color(value: string) {
+    this._color = value;
+  }
+
+  constructor(props?: any) {
+    super({ ...props, nolabel: true });
+
+    if (props) {
+      if (props.name) {
+        this._name = props.name;
+      }
+
+      if (props.size) {
+        this._size = props.size;
+      }
+
+      if (props.color) {
+        this._color = props.color;
+      }
+    }
+  }
+}
+
+export default Icon;

--- a/src/WidgetFactory.ts
+++ b/src/WidgetFactory.ts
@@ -25,6 +25,7 @@ import Separator from "./Separator";
 import Reference from "./Reference";
 import Binary from "./Binary";
 import Image from "./Image";
+import Icon from "./Icon";
 import FiberGrid from "./FiberGrid";
 import Timeline from "./Timeline";
 import Indicator from "./Indicator";
@@ -140,6 +141,9 @@ class WidgetFactory {
         break;
       case "image":
         this._widgetClass = Image;
+        break;
+      case "icon":
+        this._widgetClass = Icon;
         break;
       case "fiber_grid":
         this._widgetClass = FiberGrid;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import ActionButtons from "./ActionButtons";
 import Reference from "./Reference";
 import Binary from "./Binary";
 import Image from "./Image";
+import Icon from "./Icon";
 import { parseContext, parseContextFields } from "./helpers/contextParser";
 import {
   transformDomainForChildWidget,
@@ -111,6 +112,7 @@ export {
   Reference,
   Binary,
   Image,
+  Icon,
   parseContext,
   parseContextFields,
   transformDomainForChildWidget,

--- a/src/spec/Icon.spec.ts
+++ b/src/spec/Icon.spec.ts
@@ -1,0 +1,93 @@
+import WidgetFactory from "../WidgetFactory";
+import { it, expect, describe } from "vitest";
+
+describe("An Icon", () => {
+  it("should have an id corresponding to field name", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "icon1",
+    };
+
+    const widget = widgetFactory.createWidget("icon", props);
+
+    expect(widget.id).toBe("icon1");
+  });
+
+  it("should properly have nolabel as true by default", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "icon1",
+    };
+    const widget = widgetFactory.createWidget("icon", props);
+
+    expect(widget.nolabel).toBe(true);
+  });
+
+  it("should properly set name", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "icon1",
+    };
+    const widget = widgetFactory.createWidget("icon", props);
+
+    widget.name = "home";
+    expect(widget.name).toBe("home");
+  });
+
+  it("should properly set size", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "icon1",
+      size: 24,
+    };
+    const widget = widgetFactory.createWidget("icon", props);
+
+    expect(widget.size).toBe(24);
+  });
+
+  it("should have default size of 16", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "icon1",
+    };
+    const widget = widgetFactory.createWidget("icon", props);
+
+    expect(widget.size).toBe(16);
+  });
+
+  it("should properly set color", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "icon1",
+      color: "#FF0000",
+    };
+    const widget = widgetFactory.createWidget("icon", props);
+
+    expect(widget.color).toBe("#FF0000");
+  });
+
+  it("should have empty color by default", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "icon1",
+    };
+    const widget = widgetFactory.createWidget("icon", props);
+
+    expect(widget.color).toBe("");
+  });
+
+  it("should properly parse all props together", () => {
+    const widgetFactory = new WidgetFactory();
+    const props = {
+      name: "icon1",
+      size: 32,
+      color: "blue",
+    };
+    const widget = widgetFactory.createWidget("icon", props);
+
+    widget.name = "star";
+    expect(widget.name).toBe("star");
+    expect(widget.size).toBe(32);
+    expect(widget.color).toBe("blue");
+  });
+});


### PR DESCRIPTION
This pull request introduces a new `Icon` widget to the codebase, making it available through the widget factory and export system. It also adds comprehensive tests to ensure the correct behavior of the new widget. The main changes are grouped into the implementation of the new widget, integration into the widget system, and the addition of tests.

**Icon widget implementation and integration:**

* Added a new `Icon` class in `src/Icon.ts`, which extends `Field` and supports `name`, `size`, and `color` properties, with sensible defaults and property accessors.
* Registered the `Icon` widget in `WidgetFactory` (`src/WidgetFactory.ts`) so it can be instantiated via `createWidget`. [[1]](diffhunk://#diff-e24854d27ab93ed8dcbbb22c3c95ba2dd02f03d034d495207f1d7901951f98cdR28) [[2]](diffhunk://#diff-e24854d27ab93ed8dcbbb22c3c95ba2dd02f03d034d495207f1d7901951f98cdR145-R147)
* Exported the `Icon` widget from the module's entry point (`src/index.ts`) for external usage. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R34) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R115)

**Testing:**

* Added a new test suite in `src/spec/Icon.spec.ts` to verify the `Icon` widget's properties, defaults, and integration with the factory.