### PR TITLE
Add progressbar property to GraphIndicator

### DIFF
--- a/src/Graph/GraphIndicator.ts
+++ b/src/Graph/GraphIndicator.ts
@@ -28,6 +28,11 @@ export class GraphIndicator extends Graph {
     return this._progressbar;
   }
 
+  _showTotal: boolean = true;
+  get showTotal(): boolean {
+    return this._showTotal;
+  }
+
   _suffix: string | null = null;
   get suffix(): string | null {
     return this._suffix;
@@ -49,5 +54,9 @@ export class GraphIndicator extends Graph {
     this._totalDomain = replaceEntities(element.attributes.totalDomain) || null;
     this._showPercent = parseBoolAttribute(element.attributes.showPercent);
     this._progressbar = parseBoolAttribute(element.attributes.progressbar);
+    this._showTotal =
+      element.attributes.showTotal !== undefined
+        ? parseBoolAttribute(element.attributes.showTotal)
+        : true;
   }
 }

--- a/src/Graph/GraphIndicator.ts
+++ b/src/Graph/GraphIndicator.ts
@@ -57,6 +57,6 @@ export class GraphIndicator extends Graph {
     this._showTotal =
       element.attributes.showTotal !== undefined
         ? parseBoolAttribute(element.attributes.showTotal)
-        : true;
+        : !!this._totalDomain;
   }
 }

--- a/src/Graph/GraphIndicator.ts
+++ b/src/Graph/GraphIndicator.ts
@@ -23,6 +23,11 @@ export class GraphIndicator extends Graph {
     return this._showPercent;
   }
 
+  _progressbar: boolean = false;
+  get progressbar(): boolean {
+    return this._progressbar;
+  }
+
   _suffix: string | null = null;
   get suffix(): string | null {
     return this._suffix;
@@ -43,5 +48,6 @@ export class GraphIndicator extends Graph {
     this._suffix = element.attributes.suffix || null;
     this._totalDomain = replaceEntities(element.attributes.totalDomain) || null;
     this._showPercent = parseBoolAttribute(element.attributes.showPercent);
+    this._progressbar = parseBoolAttribute(element.attributes.progressbar);
   }
 }

--- a/src/spec/Graph.spec.ts
+++ b/src/spec/Graph.spec.ts
@@ -55,6 +55,31 @@ describe("A Graph", () => {
     expect(graph.field).toBe("potencia");
     expect(graph.operator).toBe("+");
   });
+  it("should parse progressbar and showPercent attributes", () => {
+    const xml1 = `<?xml version="1.0"?>
+    <graph string="My indicator" type="indicator" progressbar="1" />
+    `;
+
+    const graph1 = parseGraph(xml1) as GraphIndicator;
+    expect(graph1.progressbar).toBe(true);
+    expect(graph1.showPercent).toBe(false);
+
+    const xml2 = `<?xml version="1.0"?>
+    <graph string="My indicator" type="indicator" showPercent="1" />
+    `;
+
+    const graph2 = parseGraph(xml2) as GraphIndicator;
+    expect(graph2.showPercent).toBe(true);
+    expect(graph2.progressbar).toBe(false);
+
+    const xml3 = `<?xml version="1.0"?>
+    <graph string="My indicator" type="indicator" />
+    `;
+
+    const graph3 = parseGraph(xml3) as GraphIndicator;
+    expect(graph3.showPercent).toBe(false);
+    expect(graph3.progressbar).toBe(false);
+  });
   it("should parse a graph with timerange parameter", () => {
     const xml = `<?xml version="1.0"?>
     <graph type="line" timerange="day">

--- a/src/spec/Graph.spec.ts
+++ b/src/spec/Graph.spec.ts
@@ -63,7 +63,7 @@ describe("A Graph", () => {
     const graph1 = parseGraph(xml1) as GraphIndicator;
     expect(graph1.progressbar).toBe(true);
     expect(graph1.showPercent).toBe(false);
-    expect(graph1.showTotal).toBe(true);
+    expect(graph1.showTotal).toBe(false); // No totalDomain, should default to false
 
     const xml2 = `<?xml version="1.0"?>
     <graph string="My indicator" type="indicator" showPercent="1" />
@@ -72,7 +72,7 @@ describe("A Graph", () => {
     const graph2 = parseGraph(xml2) as GraphIndicator;
     expect(graph2.showPercent).toBe(true);
     expect(graph2.progressbar).toBe(false);
-    expect(graph2.showTotal).toBe(true);
+    expect(graph2.showTotal).toBe(false); // No totalDomain, should default to false
 
     const xml3 = `<?xml version="1.0"?>
     <graph string="My indicator" type="indicator" />
@@ -81,7 +81,7 @@ describe("A Graph", () => {
     const graph3 = parseGraph(xml3) as GraphIndicator;
     expect(graph3.showPercent).toBe(false);
     expect(graph3.progressbar).toBe(false);
-    expect(graph3.showTotal).toBe(true);
+    expect(graph3.showTotal).toBe(false); // No totalDomain, should default to false
 
     const xml4 = `<?xml version="1.0"?>
     <graph string="My indicator" type="indicator" showTotal="0" />
@@ -89,6 +89,31 @@ describe("A Graph", () => {
 
     const graph4 = parseGraph(xml4) as GraphIndicator;
     expect(graph4.showTotal).toBe(false);
+  });
+  it("should set showTotal to true when totalDomain is defined", () => {
+    const xml1 = `<?xml version="1.0"?>
+    <graph string="My indicator" type="indicator" totalDomain="[('state','=','open')]" />
+    `;
+
+    const graph1 = parseGraph(xml1) as GraphIndicator;
+    expect(graph1.totalDomain).toBe("[('state','=','open')]");
+    expect(graph1.showTotal).toBe(true); // totalDomain is defined, should default to true
+
+    const xml2 = `<?xml version="1.0"?>
+    <graph string="My indicator" type="indicator" totalDomain="[('state','=','open')]" showTotal="0" />
+    `;
+
+    const graph2 = parseGraph(xml2) as GraphIndicator;
+    expect(graph2.totalDomain).toBe("[('state','=','open')]");
+    expect(graph2.showTotal).toBe(false); // Explicitly set to false
+
+    const xml3 = `<?xml version="1.0"?>
+    <graph string="My indicator" type="indicator" totalDomain="[('state','=','open')]" showTotal="1" />
+    `;
+
+    const graph3 = parseGraph(xml3) as GraphIndicator;
+    expect(graph3.totalDomain).toBe("[('state','=','open')]");
+    expect(graph3.showTotal).toBe(true); // Explicitly set to true
   });
   it("should parse a graph with timerange parameter", () => {
     const xml = `<?xml version="1.0"?>

--- a/src/spec/Graph.spec.ts
+++ b/src/spec/Graph.spec.ts
@@ -55,7 +55,7 @@ describe("A Graph", () => {
     expect(graph.field).toBe("potencia");
     expect(graph.operator).toBe("+");
   });
-  it("should parse progressbar and showPercent attributes", () => {
+  it("should parse progressbar, showPercent and showTotal attributes", () => {
     const xml1 = `<?xml version="1.0"?>
     <graph string="My indicator" type="indicator" progressbar="1" />
     `;
@@ -63,6 +63,7 @@ describe("A Graph", () => {
     const graph1 = parseGraph(xml1) as GraphIndicator;
     expect(graph1.progressbar).toBe(true);
     expect(graph1.showPercent).toBe(false);
+    expect(graph1.showTotal).toBe(true);
 
     const xml2 = `<?xml version="1.0"?>
     <graph string="My indicator" type="indicator" showPercent="1" />
@@ -71,6 +72,7 @@ describe("A Graph", () => {
     const graph2 = parseGraph(xml2) as GraphIndicator;
     expect(graph2.showPercent).toBe(true);
     expect(graph2.progressbar).toBe(false);
+    expect(graph2.showTotal).toBe(true);
 
     const xml3 = `<?xml version="1.0"?>
     <graph string="My indicator" type="indicator" />
@@ -79,6 +81,14 @@ describe("A Graph", () => {
     const graph3 = parseGraph(xml3) as GraphIndicator;
     expect(graph3.showPercent).toBe(false);
     expect(graph3.progressbar).toBe(false);
+    expect(graph3.showTotal).toBe(true);
+
+    const xml4 = `<?xml version="1.0"?>
+    <graph string="My indicator" type="indicator" showTotal="0" />
+    `;
+
+    const graph4 = parseGraph(xml4) as GraphIndicator;
+    expect(graph4.showTotal).toBe(false);
   });
   it("should parse a graph with timerange parameter", () => {
     const xml = `<?xml version="1.0"?>


### PR DESCRIPTION
This pull request adds support for a new `progressbar` attribute to the `GraphIndicator` class, allowing indicator graphs to optionally display a progress bar. It also updates the parsing logic and tests to handle this new attribute alongside the existing `showPercent` attribute.

**GraphIndicator enhancements:**

* Added a `_progressbar` property and a corresponding getter to the `GraphIndicator` class to represent the new `progressbar` attribute.
* Updated the constructor of `GraphIndicator` to parse the `progressbar` attribute from XML using `parseBoolAttribute`.

**Testing improvements:**

* Added unit tests to verify correct parsing of the `progressbar` and `showPercent` attributes in various combinations.

## Related
- https://github.com/gisce/webclient/issues/2656