### PR TITLE
update gisce/commitlint-rules to v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@commitlint/cli": "^18.4.3",
-        "@gisce/commitlint-rules": "1.0.5",
+        "@gisce/commitlint-rules": "1.1.0",
         "@semantic-release/exec": "6.0.3",
         "@semantic-release/git": "10.0.1",
         "@semantic-release/npm": "10.0.4",
@@ -1121,15 +1121,12 @@
       }
     },
     "node_modules/@gisce/commitlint-rules": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@gisce/commitlint-rules/-/commitlint-rules-1.0.5.tgz",
-      "integrity": "sha512-L3czIEMS8gYbGpJEg3xHpby6QPWuhRGFJ4NsPuRLA9uFfDTTVOq19Y2jrnt0UNg6zOJKwRVSdkX5Aio8gTP1dg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@gisce/commitlint-rules/-/commitlint-rules-1.1.0.tgz",
+      "integrity": "sha512-klvV6H12EgGcf2PrOZ3nqjakhn1V7/toqCaclaS5U2QPuG43lO98GyU4Snn9NfUyywQ21x+iztofd9GNVyPGgA==",
       "dev": true,
       "dependencies": {
         "@commitlint/config-conventional": "^18.4.3"
-      },
-      "engines": {
-        "node": "20.5.0"
       }
     },
     "node_modules/@gisce/conscheck": {
@@ -14315,9 +14312,9 @@
       "dev": true
     },
     "@gisce/commitlint-rules": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@gisce/commitlint-rules/-/commitlint-rules-1.0.5.tgz",
-      "integrity": "sha512-L3czIEMS8gYbGpJEg3xHpby6QPWuhRGFJ4NsPuRLA9uFfDTTVOq19Y2jrnt0UNg6zOJKwRVSdkX5Aio8gTP1dg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@gisce/commitlint-rules/-/commitlint-rules-1.1.0.tgz",
+      "integrity": "sha512-klvV6H12EgGcf2PrOZ3nqjakhn1V7/toqCaclaS5U2QPuG43lO98GyU4Snn9NfUyywQ21x+iztofd9GNVyPGgA==",
       "dev": true,
       "requires": {
         "@commitlint/config-conventional": "^18.4.3"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^18.4.3",
-    "@gisce/commitlint-rules": "1.0.5",
+    "@gisce/commitlint-rules": "1.1.0",
     "@semantic-release/exec": "6.0.3",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/npm": "10.0.4",


### PR DESCRIPTION
This PR updates [gisce/commitlint-rules](https://github.com/gisce/commitlint-rules) to [v1.1.0](https://github.com/gisce/commitlint-rules/releases/tag/v1.1.0).