### PR TITLE
update gisce/conscheck to v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@gisce/ooui",
       "version": "2.43.0",
       "dependencies": {
-        "@gisce/conscheck": "1.0.9",
+        "@gisce/conscheck": "1.1.0",
         "html-entities": "^2.3.3",
         "moment": "^2.29.3",
         "txml": "^5.1.1"
@@ -1130,12 +1130,9 @@
       }
     },
     "node_modules/@gisce/conscheck": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@gisce/conscheck/-/conscheck-1.0.9.tgz",
-      "integrity": "sha512-lEC0ShBY/klknvK1dZqRz4RIJxCuI0UJOI8KQMI/os+48U3qtpE+1pGQbxywhmNHVssKQRo2qOwDRu+zNZm6ag==",
-      "engines": {
-        "node": "20.5.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@gisce/conscheck/-/conscheck-1.1.0.tgz",
+      "integrity": "sha512-48DLq6RyC9krV7akW8HYdCMU2Ra8UrNZztQAJJpsMk8TbhZBAOfjEKmrYNC04yblzSDIfUkBVK9jPN0ZXQMK4w=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.11",
@@ -14321,9 +14318,9 @@
       }
     },
     "@gisce/conscheck": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@gisce/conscheck/-/conscheck-1.0.9.tgz",
-      "integrity": "sha512-lEC0ShBY/klknvK1dZqRz4RIJxCuI0UJOI8KQMI/os+48U3qtpE+1pGQbxywhmNHVssKQRo2qOwDRu+zNZm6ag=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@gisce/conscheck/-/conscheck-1.1.0.tgz",
+      "integrity": "sha512-48DLq6RyC9krV7akW8HYdCMU2Ra8UrNZztQAJJpsMk8TbhZBAOfjEKmrYNC04yblzSDIfUkBVK9jPN0ZXQMK4w=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.11",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "analyze": "npx vite-bundle-visualizer"
   },
   "dependencies": {
-    "@gisce/conscheck": "1.0.9",
+    "@gisce/conscheck": "1.1.0",
     "html-entities": "^2.3.3",
     "moment": "^2.29.3",
     "txml": "^5.1.1"


### PR DESCRIPTION
This PR updates [gisce/conscheck](https://github.com/gisce/conscheck) to [v1.1.0](https://github.com/gisce/conscheck/releases/tag/v1.1.0).